### PR TITLE
Allow overriding package through callPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ $ ls backup
 1. Update actual version in `README.md` and `package.json` (e.g. `25.4.0` to `25.5.0`).
 2. Run `devenv shell`
 3. Run `npm install` to update the package.lock file (otherwise `nix build` won't work)
-4. Replace `npmDepsHash = "sha256-ZTfXjTZE5f...";` in `flake.nix` with `npmDepsHash = pkgs.lib.fakeHash;`
+4. Replace `npmDepsHash ? "sha256-ZTfXjTZE5f...";` in `actual-backup.nix` with `npmDepsHash ? lib.fakeHash;`
 5. Run `nix build` and copy the `got:    sha256-HaOhKSfkFC4PAvO...`
-6. Replace `npmDepsHash = pkgs.lib.fakeHash;` with the new hash (i.e. `npmDepsHash = "sha256-HaOhKSfkFC4PAvO...";`).
+6. Replace `npmDepsHash ? lib.fakeHash;` with the new hash (i.e. `npmDepsHash ? "sha256-HaOhKSfkFC4PAvO...";`).
 7. Run `nix build` again. It should now succeed.
 8. Test changes.
 9. If it works, commit the change or open a PR.

--- a/actual-backup.nix
+++ b/actual-backup.nix
@@ -1,0 +1,98 @@
+{
+  buildNpmPackage,
+  lib,
+  nodePackages,
+  typescript ? nodePackages.typescript,
+  nodejs,
+  version ? "25.7.1",
+  # Hash of the node_modules structure based on package-lock.json.
+  # Ensures reproducible dependency fetching.
+  # If dependencies change (package-lock.json updated), `nix build` will fail
+  # with a hash mismatch, providing the correct hash to paste here.
+  npmDepsHash ? "sha256-AN0comIgRz3fFYu7UV2Mk5d4szrWM5sCLD/AwZsHqRg=",
+  # npmDepsHash ? lib.fakeHash,
+  ...
+}:
+buildNpmPackage {
+  pname = "actual-backup-tool";
+
+  inherit version npmDepsHash;
+
+  src = ./.;
+
+  # Allow build scripts to write to the npm cache if needed.
+  makeCacheWritable = true;
+
+  # Specify the build script from package.json ("scripts": { "build": "tsc" })
+  npmBuildScript = "build";
+
+  # --- Build-time Dependencies ---
+  # Packages needed ONLY on the build machine to build the application.
+  # They are *not* included in the final runtime closure unless also in buildInputs.
+  nativeBuildInputs = [
+    nodejs # Needed for npm/node commands during build
+    typescript # Needed for the `tsc` command during the build script
+  ];
+  # --- Runtime Dependencies ---
+  # Packages needed by the application when it runs.
+  buildInputs = [
+    nodejs # Node.js runtime is required to execute the compiled JS
+  ];
+
+  # Disable the default npm install command provided by buildNpmPackage.
+  # We handle the installation process manually in installPhase for more control.
+  dontNpmInstall = true;
+
+  # Custom installation script run after the build step.
+  # This phase copies the necessary built artifacts into the Nix store ($out).
+  installPhase = ''
+    # Run standard pre-installation hooks
+    runHook preInstall
+
+    # Create the directory structure within the output path ($out)
+    # - $out/libexec/actual-backup: Holds the application code and node_modules
+    # - $out/bin: Holds the executable wrapper script
+    mkdir -p $out/libexec/actual-backup $out/bin
+
+    # Copy the compiled JavaScript code from the build step (`tsc` output)
+    echo "Copying compiled dist directory..."
+    cp -R ./dist $out/libexec/actual-backup/
+
+    # Copy the node_modules directory prepared by buildNpmPackage's internal steps.
+    # This directory contains ALL dependencies (including devDependencies) because
+    # NODE_ENV was not set to production *before* the build step, allowing `tsc`
+    # (a devDependency) and its types (`@types/node`) to be found.
+    echo "Copying prepared node_modules directory..."
+    cp -R ./node_modules $out/libexec/actual-backup/
+
+    # Copy package.json into the libexec dir. This might be needed if the
+    # application reads its own version at runtime (e.g., for a --version flag).
+    # If not needed, this copy can be removed.
+    cp ./package.json $out/libexec/actual-backup/
+
+    # Create the executable wrapper script.
+    # `substitute` replaces placeholders in `./wrapper.sh` with Nix store paths.
+    echo "Creating wrapper script..."
+    substitute ${./wrapper.sh} $out/bin/actual-backup \
+      --subst-var-by nodejs_bin_path ${nodejs}/bin/node \
+      --subst-var-by app_root $out/libexec/actual-backup \
+      --subst-var-by entry_point dist/backup-tool.js # Specify the main JS file
+
+    # Make the wrapper script executable
+    chmod +x $out/bin/actual-backup
+
+    # Run standard post-installation hooks
+    runHook postInstall
+  '';
+
+  # Metadata associated with the package
+  meta = with lib; {
+    description = "A tool to backup Actual Budget data via the API";
+    homepage = "https://github.com/Jonas-Sander/actual-backup";
+    license = licenses.mit;
+    maintainers = [
+      "Jonas-Sander"
+    ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,112 +20,24 @@
       let
         pkgs = import nixpkgs { inherit system; };
 
-        # Read the application version dynamically from package.json
-        appVersion = (builtins.fromJSON (builtins.readFile ./package.json)).version;
+        actual-backup = pkgs.callPackage ./actual-backup.nix { };
       in
       {
-        packages.actual-backup = pkgs.buildNpmPackage {
-          pname = "actual-backup-tool";
-          version = appVersion;
-
-          src = ./.;
-
-          # Hash of the node_modules structure based on package-lock.json.
-          # Ensures reproducible dependency fetching.
-          # If dependencies change (package-lock.json updated), `nix build` will fail
-          # with a hash mismatch, providing the correct hash to paste here.
-          npmDepsHash = "sha256-AN0comIgRz3fFYu7UV2Mk5d4szrWM5sCLD/AwZsHqRg=";
-          # npmDepsHash = pkgs.lib.fakeHash;
-
-          # Allow build scripts to write to the npm cache if needed.
-          makeCacheWritable = true;
-
-          # Specify the build script from package.json ("scripts": { "build": "tsc" })
-          npmBuildScript = "build";
-
-          # --- Build-time Dependencies ---
-          # Packages needed ONLY on the build machine to build the application.
-          # They are *not* included in the final runtime closure unless also in buildInputs.
-          nativeBuildInputs = [
-            pkgs.nodejs # Needed for npm/node commands during build
-            pkgs.nodePackages.typescript # Needed for the `tsc` command during the build script
-          ];
-          # --- Runtime Dependencies ---
-          # Packages needed by the application when it runs.
-          buildInputs = [
-            pkgs.nodejs # Node.js runtime is required to execute the compiled JS
-          ];
-
-          # Disable the default npm install command provided by buildNpmPackage.
-          # We handle the installation process manually in installPhase for more control.
-          dontNpmInstall = true;
-
-          # Custom installation script run after the build step.
-          # This phase copies the necessary built artifacts into the Nix store ($out).
-          installPhase = ''
-            # Run standard pre-installation hooks
-            runHook preInstall
-
-            # Create the directory structure within the output path ($out)
-            # - $out/libexec/actual-backup: Holds the application code and node_modules
-            # - $out/bin: Holds the executable wrapper script
-            mkdir -p $out/libexec/actual-backup $out/bin
-
-            # Copy the compiled JavaScript code from the build step (`tsc` output)
-            echo "Copying compiled dist directory..."
-            cp -R ./dist $out/libexec/actual-backup/
-
-            # Copy the node_modules directory prepared by buildNpmPackage's internal steps.
-            # This directory contains ALL dependencies (including devDependencies) because
-            # NODE_ENV was not set to production *before* the build step, allowing `tsc`
-            # (a devDependency) and its types (`@types/node`) to be found.
-            echo "Copying prepared node_modules directory..."
-            cp -R ./node_modules $out/libexec/actual-backup/
-
-            # Copy package.json into the libexec dir. This might be needed if the
-            # application reads its own version at runtime (e.g., for a --version flag).
-            # If not needed, this copy can be removed.
-            cp ./package.json $out/libexec/actual-backup/
-
-            # Create the executable wrapper script.
-            # `substitute` replaces placeholders in `./wrapper.sh` with Nix store paths.
-            echo "Creating wrapper script..."
-            substitute ${./wrapper.sh} $out/bin/actual-backup \
-              --subst-var-by nodejs_bin_path ${pkgs.nodejs}/bin/node \
-              --subst-var-by app_root $out/libexec/actual-backup \
-              --subst-var-by entry_point dist/backup-tool.js # Specify the main JS file
-
-            # Make the wrapper script executable
-            chmod +x $out/bin/actual-backup
-
-            # Run standard post-installation hooks
-            runHook postInstall
-          '';
-
-          # Metadata associated with the package
-          meta = with pkgs.lib; {
-            description = "A tool to backup Actual Budget data via the API";
-            homepage = "https://github.com/Jonas-Sander/actual-backup";
-            license = licenses.mit;
-            maintainers = [
-              "Jonas-Sander"
-            ];
-            platforms = platforms.linux ++ platforms.darwin;
-          };
+        packages = {
+          inherit actual-backup;
+          # Default package: `nix build .` will build this package
+          default = actual-backup;
         };
-
-        # Default package: `nix build .` will build this package
-        packages.default = self.packages.${system}.actual-backup;
 
         # Define runnable applications provided by the flake
         apps.actual-backup = {
           type = "app"; # Standard type for runnable applications
           # The command to execute when running `nix run .#actual-backup`
-          program = "${self.packages.${system}.actual-backup}/bin/actual-backup";
+          program = "${actual-backup}/bin/actual-backup";
         };
 
         # Default application: `nix run .` will run this application
-        apps.default = self.apps.${system}.actual-backup;
+        apps.default = actual-backup;
       }
     );
 }


### PR DESCRIPTION
Package was extracted into its own file (this can be undone but helps legibility) and is being instantiated through `pkgs.callPackage`(https://nix.dev/tutorials/callpackage.html) to allow flake consumers to use `.override` and `.overrideAttrs`.

Pretty minor change. Just doing it bc I did it on the way to try to solve https://github.com/Jonas-Sander/actual-backup/issues/5.